### PR TITLE
fix ipify url

### DIFF
--- a/ipprovider/ipify/ipify.go
+++ b/ipprovider/ipify/ipify.go
@@ -26,7 +26,7 @@ type ipifyResponse struct {
 func New(c *http.Client) ipprovider.Provider {
 	return &ipify{
 		c:   c,
-		url: "https://api4.ipify.org/?format=json",
+		url: "https://api.ipify.org/?format=json",
 	}
 }
 

--- a/ipprovider/ipify/ipify_test.go
+++ b/ipprovider/ipify/ipify_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIpifyNew(t *testing.T) {
-	expectedURL := "https://api4.ipify.org/?format=json"
+	expectedURL := "https://api.ipify.org/?format=json"
 	ipf := New(&http.Client{})
 	ipfOriginal := ipf.(*ipify)
 	if ipfOriginal.url != expectedURL {


### PR DESCRIPTION
The default API endpoint moved from api4.ipify.org to api.ipify.org