### PR TITLE
fix: read ddns_token env var

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -56,6 +56,7 @@ func NewConfiguration(path string) (*Configuration, error) {
 	v.AddConfigPath(".")
 	v.AddConfigPath("$HOME")
 
+	v.SetDefault("Token", "")
 	v.SetDefault("CheckPeriod", 5*time.Minute)
 	v.SetDefault("RequestTimeout", 10*time.Second)
 	v.SetDefault("IPv6", false)


### PR DESCRIPTION
Added default value to `DDNS_TOKEN` so that Viper would be able
to find the key and matching env.

More details can be found in spf13/viper#761.

Closes #31