### PR TITLE
Added multi-arch docker manifests to goreleaser configuration file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,8 +34,7 @@ changelog:
       - Merge branch
 dockers:
 - image_templates:
-  - 'skibish/ddns:{{ .Tag }}'
-  - 'skibish/ddns:latest'
+  - 'skibish/ddns:{{ .Tag }}-amd64'
   dockerfile: Dockerfile
   use: buildx
   build_flag_templates:
@@ -46,3 +45,66 @@ dockers:
   - "--label=org.opencontainers.image.version={{.Version}}"
   - "--label=org.opencontainers.image.source={{.GitURL}}"
   - "--platform=linux/amd64"
+- image_templates:
+  - 'skibish/ddns:{{ .Tag }}-arm64'
+  dockerfile: Dockerfile
+  use: buildx
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/arm64"
+- image_templates:
+  - 'skibish/ddns:{{ .Tag }}-armv6'
+  dockerfile: Dockerfile
+  use: buildx
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/arm/v6"
+- image_templates:
+  - 'skibish/ddns:{{ .Tag }}-armv7'
+  dockerfile: Dockerfile
+  use: buildx
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/arm/v7"
+- image_templates:
+  - 'skibish/ddns:{{ .Tag }}-i386'
+  dockerfile: Dockerfile
+  use: buildx
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/386"
+docker_manifests:
+- name_template: skibish/ddns:{{ .Tag }}
+  image_templates:
+  - skibish/ddns:{{ .Tag }}-amd64
+  - skibish/ddns:{{ .Tag }}-arm64
+  - skibish/ddns:{{ .Tag }}-armv6
+  - skibish/ddns:{{ .Tag }}-armv7
+  - skibish/ddns:{{ .Tag }}-i386
+- name_template: skibish/ddns:latest
+  image_templates:
+  - skibish/ddns:{{ .Tag }}-amd64
+  - skibish/ddns:{{ .Tag }}-arm64
+  - skibish/ddns:{{ .Tag }}-armv6
+  - skibish/ddns:{{ .Tag }}-armv7
+  - skibish/ddns:{{ .Tag }}-i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,8 @@ changelog:
 dockers:
 - image_templates:
   - 'skibish/ddns:{{ .Tag }}-amd64'
+  goos: linux
+  goarch: amd64
   dockerfile: Dockerfile
   use: buildx
   build_flag_templates:
@@ -52,6 +54,8 @@ dockers:
   - "--platform=linux/amd64"
 - image_templates:
   - 'skibish/ddns:{{ .Tag }}-arm64'
+  goos: linux
+  goarch: arm64
   dockerfile: Dockerfile
   use: buildx
   build_flag_templates:
@@ -64,6 +68,9 @@ dockers:
   - "--platform=linux/arm64"
 - image_templates:
   - 'skibish/ddns:{{ .Tag }}-armv6'
+  goos: linux
+  goarch: arm
+  goarm: 6
   dockerfile: Dockerfile
   use: buildx
   build_flag_templates:
@@ -76,6 +83,9 @@ dockers:
   - "--platform=linux/arm/v6"
 - image_templates:
   - 'skibish/ddns:{{ .Tag }}-armv7'
+  goos: linux
+  goarch: arm
+  goarm: 7
   dockerfile: Dockerfile
   use: buildx
   build_flag_templates:
@@ -88,6 +98,8 @@ dockers:
   - "--platform=linux/arm/v7"
 - image_templates:
   - 'skibish/ddns:{{ .Tag }}-i386'
+  goos: linux
+  goarch: 386
   dockerfile: Dockerfile
   use: buildx
   build_flag_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
     goarm:
       - 6
       - 7
+
 archives:
   - replacements:
       darwin: Darwin
@@ -20,10 +21,13 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
+
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: "{{ .Tag }}-next"
+
 changelog:
   sort: asc
   filters:
@@ -32,6 +36,7 @@ changelog:
       - '^test:'
       - Merge pull request
       - Merge branch
+
 dockers:
 - image_templates:
   - 'skibish/ddns:{{ .Tag }}-amd64'
@@ -93,6 +98,7 @@ dockers:
   - "--label=org.opencontainers.image.version={{.Version}}"
   - "--label=org.opencontainers.image.source={{.GitURL}}"
   - "--platform=linux/386"
+
 docker_manifests:
 - name_template: skibish/ddns:{{ .Tag }}
   image_templates:


### PR DESCRIPTION
Solves #30:

With this change, the goreleaser file will now make 5 docker images, one for each of the released Linux architectures.  Additionally, I've added a docker_manifests section, which will release to the docker hub a latest tag and a version tag which should contain all five architectures.  The result: Pulling the latest or a tagged version from docker hub should automatically grab the correct docker image for your architecture.

Some notes:
- Architecture-specific images are now tagged with skibish/ddns:{image version}-{architecture).  I chose this somewhat arbitrarily; can be modified to fit whatever naming scheme makes more sense.
- Due to the labels/metadata added to each image, the .goreleaser.yml file is now significantly longer.  I did this for consistency with the previous version, but there may be a cleaner way to add the metadata to every image that gets built.  Not sure how to do this, but I can look more into it if we want to make that a priority.
- I tested the build process locally using the command `goreleaser release --snapshot --rm-dist` and got a successful build, but this skips the actual deploy/push of the docker images so I haven't tested that part.  I'm reasonably certain this should just work though.  Give it a look over and maybe a quick test on your end to be sure before you merge. 