### PR TITLE
fix: gotify http method must be POST

### DIFF
--- a/notifier/gotify.go
+++ b/notifier/gotify.go
@@ -46,7 +46,7 @@ func (hook *gotifyHook) send(msg string) error {
 	form.Add("message", msg)
 
 	url := fmt.Sprintf("%s/message?token=%s", hook.AppURL, hook.AppToken)
-	req, err := http.NewRequest(http.MethodGet, url, strings.NewReader(form.Encode()))
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(form.Encode()))
 	if err != nil {
 		return fmt.Errorf("failed to create a request: %w", err)
 	}

--- a/notifier/gotify_test.go
+++ b/notifier/gotify_test.go
@@ -51,7 +51,7 @@ func TestGotifyFire(t *testing.T) {
 		t.Run(tc.tname, func(t *testing.T) {
 			is := is.New(t)
 
-			url, close := httpHelper(t, tc.tname, nil, tc.statusCode)
+			url, close := httpHelper(t, tc.tname, http.MethodPost, nil, tc.statusCode)
 			defer close()
 
 			hook, err := newGotifyhook(map[string]interface{}{

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -8,11 +8,15 @@ import (
 	"github.com/matryer/is"
 )
 
-func httpHelper(t *testing.T, response string, headers map[string]string, statusCode int) (string, func()) {
+func httpHelper(t *testing.T, response string, requestMethod string, headers map[string]string, statusCode int) (string, func()) {
 	is := is.New(t)
 	is.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		is.Helper()
+
+		is.Equal(r.Method, requestMethod)
+
 		for k, v := range headers {
 			w.Header().Add(k, v)
 		}

--- a/notifier/telegram_test.go
+++ b/notifier/telegram_test.go
@@ -41,7 +41,7 @@ func TestTelegramHookFire(t *testing.T) {
 		t.Run(tc.tname, func(t *testing.T) {
 			is := is.New(t)
 
-			url, close := httpHelper(t, tc.tname, nil, tc.statusCode)
+			url, close := httpHelper(t, tc.tname, http.MethodGet, nil, tc.statusCode)
 			defer close()
 
 			hook, err := newTelegramHook(map[string]interface{}{


### PR DESCRIPTION
Gotify expects messages to be delivered with `POST` method, not `GET` ([docs](https://gotify.net/docs/pushmsg)). Bug was introduced in https://github.com/skibish/ddns/commit/4d0ac3420389dffda70e25892465805bc9163fc7#diff-d1574fc19caffa382481ccc99b3b6509878e689a3f0a74e3e59f718d094e0a67L70-R58 (4 years ago) – typo error. This pr fixes #39 