### PR TITLE
feat: added support of rate limiter in email alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ notifications:
   from: "bar@foo.com"
   to: "foo@foo.com"
   subject: "My DDNS sending me a message"
+  rateLimit: 10 # Max 10 mails will be sent under 60 min window
 
   # Telegram (https://telegram.org)
 - type: "telegram"

--- a/notifier/rateLimiter.go
+++ b/notifier/rateLimiter.go
@@ -46,24 +46,32 @@ func (r *rateLimiterHook) RecordEvent() {
 
 func (r *rateLimiterHook) IsLimitCrossed() bool {
 
+	limitCrossed := false
+
+	defer func() {
+		if r := recover(); r != nil {
+			// Handling panic. A false will be returned in this situation
+		}
+	}()
+
 	if r.lastEventIndex == -1 {
-		return false
+		return limitCrossed
 	}
 
 	lastEventTimeStamp := r.getLastEventTimestamp()
 	oldestEventTimeStamp, completeRoundFlag := r.getOldestEventTimestamp()
 
 	if lastEventTimeStamp.Equal(oldestEventTimeStamp) {
-		return false
+		return limitCrossed
 	}
 
 	diffDuration := lastEventTimeStamp.Sub(oldestEventTimeStamp).Seconds()
 
 	if diffDuration <= r.Duration.Seconds() && completeRoundFlag {
-		return true
+		limitCrossed = true
 	}
 
-	return false
+	return limitCrossed
 }
 
 func (r *rateLimiterHook) getLastEventTimestamp() time.Time {

--- a/notifier/rateLimiter.go
+++ b/notifier/rateLimiter.go
@@ -1,0 +1,88 @@
+package notifier
+
+import (
+	"time"
+)
+
+const (
+	DEFAULT_RATE_LIMITER_DURATION = 60
+)
+
+// rateLimiterHook is a structure for rateLimiterHook configuration
+type rateLimiterHook struct {
+	// The value which controls the duration of this rate limiter, default 60 min
+	Duration time.Duration
+
+	// The value which controls the maximum number events allowed in Duration
+	MaxEvents int
+
+	// Stores the timestamps of recorded events
+	eventTimestamps []time.Time
+
+	// index to the last timestamp
+	lastEventIndex int
+}
+
+func NewRateLimiterHook(maxEvents int) *rateLimiterHook {
+	r := rateLimiterHook{
+		MaxEvents:       maxEvents,
+		eventTimestamps: make([]time.Time, maxEvents),
+		lastEventIndex:  -1,
+		Duration:        time.Minute * DEFAULT_RATE_LIMITER_DURATION,
+	}
+
+	return &r
+}
+
+func (r *rateLimiterHook) RecordEvent() {
+	if r.lastEventIndex == r.MaxEvents-1 {
+		r.lastEventIndex = 0
+	} else {
+		r.lastEventIndex = r.lastEventIndex + 1
+	}
+
+	r.eventTimestamps[r.lastEventIndex] = time.Now()
+}
+
+func (r *rateLimiterHook) IsLimitCrossed() bool {
+
+	if r.lastEventIndex == -1 {
+		return false
+	}
+
+	lastEventTimeStamp := r.getLastEventTimestamp()
+	oldestEventTimeStamp, completeRoundFlag := r.getOldestEventTimestamp()
+
+	if lastEventTimeStamp.Equal(oldestEventTimeStamp) {
+		return false
+	}
+
+	diffDuration := lastEventTimeStamp.Sub(oldestEventTimeStamp).Seconds()
+
+	if diffDuration <= r.Duration.Seconds() && completeRoundFlag {
+		return true
+	}
+
+	return false
+}
+
+func (r *rateLimiterHook) getLastEventTimestamp() time.Time {
+	return r.eventTimestamps[r.lastEventIndex]
+}
+
+func (r *rateLimiterHook) getOldestEventTimestamp() (time.Time, bool) {
+
+	completeRoundFlag := false
+
+	if r.lastEventIndex == r.MaxEvents-1 {
+		completeRoundFlag = true
+		return r.eventTimestamps[0], completeRoundFlag
+	} else if r.lastEventIndex == 0 && r.eventTimestamps[r.lastEventIndex+1].Equal(time.Time{}) {
+		return r.eventTimestamps[0], completeRoundFlag
+	} else if r.eventTimestamps[r.lastEventIndex+1].Equal(time.Time{}) {
+		return r.eventTimestamps[0], completeRoundFlag
+	} else {
+		completeRoundFlag = true
+		return r.eventTimestamps[r.lastEventIndex+1], completeRoundFlag
+	}
+}

--- a/notifier/rateLimiter_test.go
+++ b/notifier/rateLimiter_test.go
@@ -1,0 +1,74 @@
+package notifier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+func TestRateLimiter(t *testing.T) {
+
+	testCases := []struct {
+		tname        string
+		maxThreshold int
+		eventRun     int
+		duration     time.Duration
+		isErr        bool
+	}{
+		{
+			tname:        "event run under limit | rate limit not crossed",
+			maxThreshold: 5,
+			eventRun:     3,
+			duration:     time.Minute * 1,
+			isErr:        false,
+		},
+		{
+			tname:        "event run over limit | rate limit crossed",
+			maxThreshold: 5,
+			eventRun:     6,
+			duration:     time.Minute * 1,
+			isErr:        true,
+		},
+		{
+			tname:        "no event run | rate limit not crossed",
+			maxThreshold: 5,
+			eventRun:     0,
+			duration:     time.Minute * 1,
+			isErr:        false,
+		},
+		{
+			tname:        "event run equal to limit | rate limit crossed",
+			maxThreshold: 5,
+			eventRun:     5,
+			duration:     time.Minute * 1,
+			isErr:        true,
+		},
+		{
+			tname:        "event run over limit over time | rate limit not crossed",
+			maxThreshold: 5,
+			eventRun:     10,
+			duration:     time.Second * 3,
+			isErr:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.tname, func(t *testing.T) {
+			is := is.New(t)
+
+			r := NewRateLimiterHook(tc.maxThreshold)
+			r.Duration = tc.duration
+
+			for i := 0; i < tc.eventRun; i++ {
+				r.RecordEvent()
+				time.Sleep(time.Second * 1)
+			}
+
+			limitCrossed := r.IsLimitCrossed()
+
+			is.True(tc.isErr == limitCrossed)
+		})
+	}
+
+}

--- a/notifier/smtp.go
+++ b/notifier/smtp.go
@@ -18,7 +18,11 @@ type smtpHook struct {
 	From       string
 	To         string
 	Subject    string
+	RateLimit  int
 	senderFunc func() (gomail.SendCloser, error)
+
+	rateLimiterHook *rateLimiterHook
+	rateLimitActive bool
 }
 
 // newSMTPHook initializes SMTPConfig structure.
@@ -36,6 +40,13 @@ func newSMTPHook(cfg interface{}) (*smtpHook, error) {
 		return nil, fmt.Errorf("failed to parse to address: %w", err)
 	}
 
+	if hook.RateLimit != 0 {
+		hook.rateLimiterHook = &rateLimiterHook{
+			MaxEvents: hook.RateLimit,
+		}
+		hook.rateLimitActive = true
+	}
+
 	hook.senderFunc = func() (gomail.SendCloser, error) {
 		d := gomail.NewDialer(hook.Host, hook.Port, hook.User, hook.Password)
 		s, err := d.Dial()
@@ -51,6 +62,11 @@ func newSMTPHook(cfg interface{}) (*smtpHook, error) {
 
 // Fire fires hook
 func (hook *smtpHook) Fire(entry *logrus.Entry) error {
+
+	if hook.rateLimitActive && hook.rateLimiterHook.IsLimitCrossed() {
+		return fmt.Errorf("email fire rejected due to rate limit exceeded")
+	}
+
 	m := gomail.NewMessage()
 	m.SetHeader("From", hook.From)
 	m.SetHeader("To", hook.To)
@@ -64,6 +80,10 @@ func (hook *smtpHook) Fire(entry *logrus.Entry) error {
 
 	if err := gomail.Send(s, m); err != nil {
 		return err
+	}
+
+	if hook.rateLimitActive {
+		hook.rateLimiterHook.RecordEvent()
 	}
 
 	return nil


### PR DESCRIPTION
Solves #29 
Added rate limiter support in email alerts

With this change user will be able to set rate limit over email notification using configuration file, the rate limit value from configuration file applies for 60 min window i.e. only "n" amount of emails will be only sent in 60 minute time window